### PR TITLE
admin browse/delete images

### DIFF
--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminFragment.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminFragment.java
@@ -36,5 +36,16 @@ public class AdminFragment extends Fragment {
                         .addToBackStack(null).commit();
             }
         });
+
+
+        ImageButton imgListBtn = v.findViewById(R.id.nav_ad_images_btn);
+        imgListBtn.setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View view){
+                activity.getSupportFragmentManager()
+                        .beginTransaction().replace(R.id.content_main, new AdminImageList())
+                        .addToBackStack(null).commit();
+            }
+        });
     }
 }

--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminImageList.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminImageList.java
@@ -1,0 +1,179 @@
+package com.example.quickscanr;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.provider.ContactsContract;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.GridView;
+import android.widget.ImageView;
+
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+
+/**
+ * Admin Image List:
+ * - allows admin to view all the images and click on each one to view the image,
+ *   who uploaded it, and the date posted
+ */
+public class AdminImageList extends AdminFragment{
+
+
+    RecyclerView imgView;
+
+    ArrayList<Bitmap> imgList;
+    ArrayList<String> imgIdList;
+    ImgArrayAdapter imgArrayAdapter;
+    private FirebaseFirestore db;
+    private CollectionReference imgRef;
+    ImgHandler imgHandler;
+
+    public static String img_COLLECTION = "images";
+
+
+    public AdminImageList() {}
+
+    /**
+     * AdminImageList
+     *  - creates a new instance of the AdminImageList fragment
+     * @param param1
+     *      -
+     * @param param2
+     * @return
+     *  - returns fragment: which is of the new instance AdminImageList
+     */
+    public static AdminImageList newInstance(String param1, String param2) {
+        AdminImageList fragment = new AdminImageList();
+        return fragment;
+    }
+
+    /**
+     * OnCreate
+     * @param savedInstanceState If the fragment is being re-created from
+     * a previous saved state, this is the state.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    /**
+     * onCreateView
+     *  - creates the view and inflates layout so that the
+     *      browse image list can be displayed
+     *
+     * @param inflater The LayoutInflater object that can be used to inflate
+     * any views in the fragment,
+     * @param container If non-null, this is the parent view that the fragment's
+     * UI should be attached to.  The fragment should not add the view itself,
+     * but this can be used to generate the LayoutParams of the view.
+     *
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     * from a previous saved state as given here.
+     *
+     * @return
+     *      - returns v, which is the view with the inflated layout
+     */
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.admin_browse_images, container, false);
+        addNavBarListeners(getActivity(), v);
+        Log.d("DEBUG", "hi");
+
+
+//         DB LINKING
+        db = FirebaseFirestore.getInstance();
+
+        imgRef = db.collection(img_COLLECTION);
+
+        imgView = v.findViewById(R.id.view_img_list);
+        imgList = new ArrayList<>();
+        imgIdList = new ArrayList<>();
+
+
+        //so that the events show up
+        addListeners();
+        imgView.setLayoutManager(new GridLayoutManager(getContext(), 3));
+
+        imgHandler = new ImgHandler(getContext());
+
+        // Assuming you have the document ID of the image
+//        String documentId = "bbfAFiW1uJ2aVxZl5oit";
+
+        addSnapshotListenerForEvent();
+
+        return v;
+    }
+
+    //snapshot is for real time updates
+    /**
+     * addSnapshotListenerForEvent()
+     *  - snapshot listener for the firestore database to listen to the image collection
+     *  - anytime there are any changes within the database it updates
+     */
+    private void addSnapshotListenerForEvent() {
+        imgRef.addSnapshotListener((value, error) -> {
+            if (error != null) {
+                Log.e("DEBUG: AEL", error.getMessage());
+                return;
+            }
+
+            if (value == null) {
+                return;
+            }
+
+            imgList.clear();
+            for (QueryDocumentSnapshot doc: value) {
+                String eventName = doc.getString(DatabaseConstants.imgDataKey);
+                Bitmap bitmap = ImgHandler.base64ToBitmap(eventName);
+                String imgid = doc.getString(DatabaseConstants.imgId);
+
+                imgList.add(bitmap);
+                imgIdList.add(imgid);
+                Log.d("DEBUG", "IMAGE Id HERE" + imgid);
+
+
+                Log.d("DEBUG", String.format("Img (%s) fetched: ", bitmap));
+            }
+            imgArrayAdapter.notifyDataSetChanged();
+
+        });
+    }
+
+    //listen for the clickable items
+    /**
+     * addListeners:
+     *  - create eventArrayAdapter and set it as the adapter for the recycler view
+     *  - keeps track of position when event is clicked
+     */
+    public void addListeners() {
+        imgArrayAdapter = new ImgArrayAdapter(getContext(), imgList, imgIdList, (position, imageId) -> buttonClickAction(imgList.get(position), imgIdList.get(position)));
+        imgView.setAdapter(imgArrayAdapter);
+    }
+
+    /**
+     * buttonClickAction:
+     *  - when image is clicked, it will send specific data to AdminManageImage page
+     *  - includes ability to move forward and backwards to different pages
+     */
+
+    private void buttonClickAction(Bitmap bitmap, String imageId) {
+        //When you click on the buttonClickAction, it will link the position and take you
+        //to the manage image that fills in more info
+
+        getActivity().getSupportFragmentManager().beginTransaction()
+                .replace(R.id.content_main, AdminManageImage.newInstance(bitmap, imageId))
+                .addToBackStack(null).commit();
+    }
+}

--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminManageImage.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/AdminManageImage.java
@@ -1,0 +1,147 @@
+package com.example.quickscanr;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.UUID;
+
+/**
+ * AdminManageImage
+ * - allows admin to view more info about the image and who uploaded it
+ */
+public class AdminManageImage extends InnerPageFragment{
+
+    private Bitmap bitmap;
+
+    private String img_id;
+    private ImgHandler imgHandler;
+
+    Button deleteImages;
+
+    private FirebaseFirestore db;
+    private CollectionReference imgRef;
+    public static String IMAGE_COLLECTION = "images";
+
+    public AdminManageImage(Bitmap bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    //On create we need to inflate the xml and create the fragment that can be connected to the image page
+    /**
+     * onCreate:
+     * @param savedInstanceState If the fragment is being re-created from
+     * a previous saved state, this is the state.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            bitmap = (Bitmap) getArguments().getParcelable("image");
+            img_id = getArguments().getString("imageId");
+        }
+    }
+
+    /**
+     * onCreateView:
+     *
+     * @param inflater The LayoutInflater object that can be used to inflate
+     * any views in the fragment,
+     * @param container If non-null, this is the parent view that the fragment's
+     * UI should be attached to.  The fragment should not add the view itself,
+     * but this can be used to generate the LayoutParams of the view.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     * from a previous saved state as given here.
+     *
+     * @return
+     *       - returns v, which is the view with the inflated layout
+     *       - also returns the updated version of any change made with deleting
+     */
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.admin_manage_image, container, false);
+        //go back to events list when clicked
+        addButtonListeners(getActivity(), v);
+        populateInfo(v);
+
+        deleteImages = v.findViewById(R.id.delete_img);
+
+
+        //set up the database
+        db = FirebaseFirestore.getInstance();
+        imgRef = db.collection(IMAGE_COLLECTION);
+
+
+
+        deleteImages.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                imgRef.whereEqualTo("imageId", img_id)
+                        .get()
+                        .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
+                            @Override
+                            public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
+                                for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
+                                    String docId = doc.getId();
+                                    imgRef.document(docId).delete();
+
+                                    //go back to the previous page
+                                    AdminImageList adminImageList = new AdminImageList();
+                                    getActivity().getSupportFragmentManager().beginTransaction()
+                                            .replace(R.id.content_main, adminImageList)
+                                            .addToBackStack(null).commit();
+                                }
+                            }
+                        });
+
+
+            }
+        });
+
+
+        return v;
+    }
+
+    /**
+     *
+     * @param bitmap: specific data regarding image
+     * @param imageId: the imageid of the picture clicked
+     * @return
+     */
+    public static AdminManageImage newInstance(Bitmap bitmap, String imageId) {
+        AdminManageImage fragment = new AdminManageImage(bitmap);
+        Bundle args = new Bundle();
+
+        args.putParcelable("image", bitmap);
+        args.putString("imageId", imageId);
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    /**
+     *populateInfo:
+     *  - populate image, info about profile, date
+     * @param v: view that has the fields with the same data that we will populate the fields with
+     */
+    public void populateInfo(View v){
+        ImageView img = v.findViewById(R.id.img_pic);
+        img.setImageBitmap(bitmap);
+
+    }
+}

--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/DatabaseConstants.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/DatabaseConstants.java
@@ -41,6 +41,8 @@ public class DatabaseConstants {
 
     // Images
     public static final String imgDataKey = "image";
+    public static final String imgId = "imageId";
+
 
     // QR CODE (not 100% DB but fits good here)
     public static final String qrTypeCheckIn = "CI";

--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/ImgArrayAdapter.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/ImgArrayAdapter.java
@@ -1,0 +1,60 @@
+package com.example.quickscanr;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.GridView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+/**
+ * ImgArrayAdapter
+ * - - this class is for populating the recycler view with different images
+ *  * - the methods are for inflating views, binding positions and getting the size of img list
+ */
+public class ImgArrayAdapter extends RecyclerView.Adapter<ImgItemView> {
+    private final ArrayList<Bitmap> images;
+    private final ArrayList<String> ids;
+    private final Context context;
+    private final ImgArrayAdapter.buttonListener listener;
+
+    public ImgArrayAdapter(Context context, ArrayList<Bitmap> images, ArrayList<String> ids, ImgArrayAdapter.buttonListener listener) {
+        this.images = images;
+        this.ids = ids;
+        this.context = context;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ImgItemView onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(context).inflate(R.layout.adm_img_item, parent, false);
+        return new ImgItemView(view, listener, ids);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ImgItemView holder, int position) {
+        Bitmap image = images.get(position);
+        String id = ids.get(position);
+        holder.image.setImageBitmap(image);
+    }
+
+    public int getItemCount() {
+        return images.size();
+    }
+
+    public interface buttonListener {
+        /**
+         *
+         * @param position: position of the clicked item
+         * @param imageId: same position as the image
+         */
+        void onClickButton(int position, String imageId);
+
+    }
+}

--- a/code/QuickScanR/app/src/main/java/com/example/quickscanr/ImgItemView.java
+++ b/code/QuickScanR/app/src/main/java/com/example/quickscanr/ImgItemView.java
@@ -1,0 +1,59 @@
+package com.example.quickscanr;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.View;
+import android.widget.GridView;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+/**
+ * ImgItemView
+ * - this is for what is is being displayed for each image that is listed
+ * - also for capturing the position when the item is clicked on
+ */
+public class ImgItemView extends RecyclerView.ViewHolder {
+
+    public ImageView image;
+    private final ArrayList<String> ids;
+
+
+
+    /**
+     * AdminEventItemView:
+     *  - represents an item in the recycler view and defines what elements need
+     *      to be displayed in the view
+     *
+     * @param itemView : the view for what is displayed on the layout (name, desc, image, etc)
+     * @param listener : listens to when button is clicked and gets position
+     */
+    public ImgItemView(View itemView, ImgArrayAdapter.buttonListener listener, ArrayList<String> ids) {
+        super(itemView);
+        this.ids = ids;
+        image = itemView.findViewById(R.id.evt_img);
+
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                int position = getAdapterPosition();
+                String imageId = getImgId(position);
+                Log.d("button", "onClick:" + getAdapterPosition());
+                listener.onClickButton(position, imageId);
+            }
+        });
+
+    }
+
+    private String getImgId(int position){
+        if(position < ids.size()){
+            return ids.get(position);
+        }
+        return null;
+    }
+}

--- a/code/QuickScanR/app/src/main/res/layout/adm_img_item.xml
+++ b/code/QuickScanR/app/src/main/res/layout/adm_img_item.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingRight="5dp"
+    android:paddingBottom="10dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rect_rounded_button"
+        android:baselineAligned="true"
+        android:orientation="vertical">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/evt_img"
+                android:layout_width="95dp"
+                android:layout_height="95dp"
+                android:background="@drawable/rect_rounded_button"
+                android:clipToOutline="true"
+                android:scaleType="centerCrop"
+                app:srcCompat="@mipmap/ic_launcher" />
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/code/QuickScanR/app/src/main/res/layout/admin_browse_images.xml
+++ b/code/QuickScanR/app/src/main/res/layout/admin_browse_images.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/admin_browse_images"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:paddingLeft="40dp"
+    android:paddingTop="50dp"
+    android:paddingRight="40dp"
+    android:paddingBottom="50dp"
+    tools:context=".AdminImageList">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/brwse_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="15dp"
+            android:text="Browse Images"
+            android:textSize="32sp" />
+
+        <EditText
+            android:layout_width="305dp"
+            android:layout_height="70dp"
+            android:background="@drawable/rounded_image_border"
+            android:hint="Type to filter"
+            android:padding="18dp"
+            android:paddingEnd="50dp" />
+
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/view_img_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clipToPadding="false"
+                android:paddingTop="15dp"
+                app:spanCount="3"
+                tools:listitem="@layout/adm_img_item">
+
+            </androidx.recyclerview.widget.RecyclerView>
+
+        </androidx.core.widget.NestedScrollView>
+
+
+    </LinearLayout>
+
+
+    <include
+        layout="@layout/admin_nav_bar" />
+
+
+</FrameLayout>

--- a/code/QuickScanR/app/src/main/res/layout/admin_manage_image.xml
+++ b/code/QuickScanR/app/src/main/res/layout/admin_manage_image.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/admin_manage_img_page"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:paddingLeft="40dp"
+    android:paddingTop="50dp"
+    android:paddingRight="40dp"
+    android:paddingBottom="50dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingBottom="25dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/back_btn"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                app:backgroundTint="#FFFFFF"
+                app:cornerRadius="16dp"
+                app:icon="?attr/homeAsUpIndicator"
+                app:iconGravity="textStart"
+                app:iconPadding="0dp"
+                app:iconSize="24dp"
+                app:iconTint="@color/black"
+                app:rippleColor="#00FFFFFF"
+                app:strokeColor="#000000"
+                app:strokeWidth="2dp" />
+
+            <TextView
+                android:id="@+id/mng_img"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="12dp"
+                android:text="Manage Image"
+                android:textSize="32sp" />
+
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/rect_rounded_button"
+                android:padding="5dp">
+
+                <ImageView
+                    android:id="@+id/img_pic"
+                    android:layout_width="match_parent"
+                    android:layout_height="298dp"
+                    android:background="@drawable/rect_rounded_button"
+                    android:clipToOutline="true"
+                    android:cropToPadding="true"
+                    android:scaleType="fitXY"
+                    app:srcCompat="@mipmap/ic_launcher" />
+            </FrameLayout>
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/img_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="25dp"
+            android:text="Profile Name"
+            android:textSize="24sp" />
+
+        <TextView
+            android:id="@+id/img_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Event Date"
+            android:textSize="24sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="12dp"
+            android:gravity="bottom"
+            android:orientation="horizontal">
+
+
+            <Button
+                android:id="@+id/delete_img"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_weight="1"
+                android:backgroundTint="#D39494"
+                android:text="Delete"
+                android:textColor="#000000"
+                android:textSize="20sp"
+                tools:ignore="ButtonStyle" />
+        </LinearLayout>
+
+
+    </LinearLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Admin can be able to browse images and delete them
- using AdminImgList, ImgItemView, ImgArrayAdapter, AdminManageImage
- made changes to database constants to add image Id 
- changes to admin fragment to enable image button
-
- Changes still need to be made but are not in this commit:
- having a field in the image that links to the uploaded profile  - in progress 
- automatic id's when uploading a photo - in progress